### PR TITLE
Fix the typescript declaration in the built files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "source": "./src/index.ts",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.modern.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "module": "./dist/index.modern.js",
       "import": "./dist/index.modern.mjs",
       "default": "./dist/index.umd.js"
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "compile": "microbundle build -f modern,umd --globals react=React",
+    "compile": "microbundle build -f modern,umd --tsconfig tsconfig.build.json --globals react=React",
     "postcompile": "cp dist/index.modern.mjs dist/index.modern.js && cp dist/index.modern.mjs.map dist/index.modern.js.map",
     "test": "run-s eslint tsc-test vitest playwright",
     "eslint": "eslint --cache --ext .js,.ts,.tsx .",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "noEmit": true,
     "jsx": "react",
     "baseUrl": ".",
     "skipLibCheck": true,


### PR DESCRIPTION
See https://github.com/jotaijs/jotai-urql/pull/11#issuecomment-1513180634

This adds a separate tsconfig for microbundle to use for generating the .d.ts declaration files.

This is the output dist/ folder when running `npm compile`:

```
dist/atomWithMutation.d.ts
dist/atomWithQuery.d.ts
dist/atomWithSubscription.d.ts
dist/clientAtom.d.ts
dist/common.d.ts
dist/index.d.ts
dist/index.modern.js
dist/index.modern.js.map
dist/index.modern.mjs
dist/index.modern.mjs.map
dist/index.umd.js
dist/index.umd.js.map
dist/suspenseAtom.d.ts
dist/types.d.ts
```